### PR TITLE
Drop the use of head, replace png-size and jpeg-size libraries by image-size

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -8,13 +8,11 @@ var Emitter = require('events').EventEmitter;
 var throttle = require('throttleit');
 var schema = require('./schemas/item');
 var FormData = require('form-data');
-var jpgSize = require('jpeg-size');
-var pngSize = require('png-size');
+var sizeOf = require('image-size');
 var dates = require('./dates');
 var error = require('./error');
 var only = require('only');
 var http = require('http');
-var head = require('head');
 var mime = require('mime');
 var path = require('path');
 var url = require('url');
@@ -233,7 +231,7 @@ Item.prototype.create = function(len, fn){
   var path = this.filename || this._file;
   var stream = this.stream;
 
-  dimensions(path, function(err, dims){
+  sizeOf(path, function(err, dims){
     if (err) return fn(err);
 
     // TODO: use schema to copy over
@@ -333,7 +331,7 @@ Item.prototype.thumb = function(path, fn){
   var key = this.s3_key + '-thumb' + extname(path);
   debug('upload thumb %s %s as %s', path, type, key);
 
-  dimensions(path, function(err, dims){
+  sizeOf(path, function(err, dims){
     if (err) return fn(err);
     var form = self.form(key);
     var len = size(path);
@@ -558,43 +556,5 @@ function submit(form, url, fn) {
     req.on('response', function(res){
       fn(null, res);
     });
-  });
-}
-
-/**
- * Get image dimensions of `file` and
- * invoke `fn(err, dims)`.
- *
- * @param {String} file
- * @param {Function} fn
- * @api private
- */
-
-function dimensions(file, fn) {
-  var ext = extname(file);
-  if (!ext) return fn();
-
-  ext = ext.toLowerCase();
-  var jpg = '.jpg' == ext || '.jpeg' == ext;
-  var png = '.png' == ext;
-
-  // ignore
-  if (!jpg && !png) return fn();
-
-  // jpg
-  // TODO: stream from the tail end of this and .write()
-  // this buffer to increase efficiency
-  if (jpg) {
-    head(file, 100 * 1024, function(err, buf){
-      if (err) return fn(err);
-      fn(null, jpgSize(buf));
-    });
-    return;
-  }
-
-  // png
-  head(file, 100, function(err, buf){
-    if (err) return fn(err);
-    fn(null, pngSize(buf));
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudup-client",
   "description": "cloudup api client",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "keywords": [
     "cloudup",
     "api",
@@ -20,9 +20,7 @@
     "uid2": "0.0.3",
     "form-data": "~0.1.0",
     "cloudup-ua": "1.0.0",
-    "png-size": "~0.1.0",
-    "jpeg-size": "0.0.1",
-    "head": "~1.0.0",
+    "image-size": "0.6.0",
     "extend": "~1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Drop the use of head, replace png-size and jpeg-size libraries by image-size